### PR TITLE
fix(shared answer.ts): fix parseAnswer

### DIFF
--- a/packages/shared/src/functions/Answer.ts
+++ b/packages/shared/src/functions/Answer.ts
@@ -11,12 +11,12 @@ export function normalizedValue(str: string): string {
   return value;
 }
 
-export function removePrefix(str: string) {
-  const prefix = ['le', 'un', 'la', 'une', 'les', 'des'];
+export function removePrefix(str: string): string {
+  const prefix = ['le', 'un', 'la', 'une', 'les', 'des', 'de'];
   const splitAnswer = str.split(' ');
   if (prefix.includes(splitAnswer[0])) {
     splitAnswer.shift();
-    return splitAnswer.join(' ');
+    return removePrefix(splitAnswer.join(' '));
   }
   return str;
 }

--- a/packages/shared/tests/Answer.spec.ts
+++ b/packages/shared/tests/Answer.spec.ts
@@ -8,6 +8,7 @@ test('Parse answer', (assert: Assert) => {
   assert.equal(parseAnswer('DescriPTION'), 'description');
   assert.equal(parseAnswer('Guerre de cent ans'), 'guerre de cent ans');
   assert.equal(parseAnswer('Lécythiophilie'), 'lecythiophilie');
+  assert.equal(parseAnswer('De La Viande'), 'viande');
 });
 
 test('Normalized value', (assert: Assert) => {
@@ -21,4 +22,5 @@ test('Remove prefix', (assert: Assert) => {
   assert.equal(removePrefix('leedsichthys'), 'leedsichthys');
   assert.equal(removePrefix('abaissable'), 'abaissable');
   assert.equal(removePrefix('des réponses'), 'réponses');
+  assert.equal(removePrefix('de la viande'), 'viande');
 });


### PR DESCRIPTION
remove multiple stopwords at the begining of the parsed answer

fix #65