### PR TITLE
feat(answer.ts): remove l' if any at the begining of parsed answers

### DIFF
--- a/packages/shared/src/functions/Answer.ts
+++ b/packages/shared/src/functions/Answer.ts
@@ -12,6 +12,11 @@ export function normalizedValue(str: string): string {
 }
 
 export function removePrefix(str: string): string {
+  // special case : l'
+  if (str.startsWith("l'")) {
+    return str.substring(2);
+  }
+  // basic cases
   const prefix = ['le', 'un', 'la', 'une', 'les', 'des', 'de'];
   const splitAnswer = str.split(' ');
   if (prefix.includes(splitAnswer[0])) {

--- a/packages/shared/tests/Answer.spec.ts
+++ b/packages/shared/tests/Answer.spec.ts
@@ -23,4 +23,6 @@ test('Remove prefix', (assert: Assert) => {
   assert.equal(removePrefix('abaissable'), 'abaissable');
   assert.equal(removePrefix('des réponses'), 'réponses');
   assert.equal(removePrefix('de la viande'), 'viande');
+  assert.equal(removePrefix("l'ultimatum"), 'ultimatum');
+  assert.equal(removePrefix(''), '');
 });


### PR DESCRIPTION
Only remove **l'** to avoid some weird cases like _c'est_, and because we remove prefix like _le_, _la_, etc