### PR TITLE
fix: minimum allowed elapsed time

### DIFF
--- a/packages/backend/app/Class/Quiz/Quiz.ts
+++ b/packages/backend/app/Class/Quiz/Quiz.ts
@@ -34,6 +34,11 @@ const SECOND = 1000;
 
 export default class Quiz extends Room {
   /**
+   * Minimum allowed elapsed time (in ms)
+   */
+  private static minElapsedTime: number = 0.7 * SECOND;
+
+  /**
    * Used for the interval between each rounds
    */
   roundTimer: NodeJS.Timeout | null = null;
@@ -357,7 +362,7 @@ export default class Quiz extends Room {
     const elapsedTime = this.quizAnswerTimer.getElapsedTime();
     if (result.bestMatch.rating >= 0.8) {
       // correct answer
-      if (elapsedTime < 0.7) {
+      if (elapsedTime < Quiz.minElapsedTime) {
         // cheat
         if (player?.dbId) {
           await User.updateOrCreate(


### PR DESCRIPTION
We should use `700` instead of `0.7`, since `elapsedTime` is a number of milliseconds